### PR TITLE
Travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,4 +143,6 @@ script:
   - catkin_make $( [ -f $CATKIN_OPTIONS ] && cat $CATKIN_OPTIONS )
   # Run the tests, ensuring the path is set correctly.
   - source devel/setup.bash
+  - roscore &
   - catkin_make run_tests && catkin_test_results
+  - rosnode kill -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install dpkg
   - sudo apt-get install -y cmake make curl libcurl4-gnutls-dev autoconf automake libtool g++ unzip libbluetooth-dev bluez python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-ros-base ros-$ROS_DISTRO-common-msgs
+  - sudo apt-get install ros-$ROS-DISTRO-tf2-geometry-msgs
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_install:
   - sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
   - sudo apt-get update -qq
   - sudo apt-get install dpkg
-  - sudo apt-get install -y cmake make curl libcurl4-gnutls-dev autoconf automake libtool g++ unzip libbluetooth-dev bluez python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-ros-base
+  - sudo apt-get install -y cmake make curl libcurl4-gnutls-dev autoconf automake libtool g++ unzip libbluetooth-dev bluez python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-ros-base ros-$ROS_DISTRO-common-msgs
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install dpkg
   - sudo apt-get install -y cmake make curl libcurl4-gnutls-dev autoconf automake libtool g++ unzip libbluetooth-dev bluez python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-ros-base ros-$ROS_DISTRO-common-msgs
-  - sudo apt-get install ros-$ROS-DISTRO-tf2-geometry-msgs
+  - sudo apt-get install ros-$ROS_DISTRO-tf2-geometry-msgs
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ before_install:
   - cd wiiuse
   - mkdir build
   - cd build
-  - cmake .. [-DCMAKE_INSTALL_PREFIX=/usr/local] [-DCMAKE_BUILD_TYPE=Release] [-DBUILD_EXAMPLE_SDL=NO]
+  - cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLE_SDL=NO
   - make && sudo make install
   # Install apriltag
   - cd ~

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,9 @@
 #     `wstool`, and should be listROS kineticed in a file named dependencies.rosinstall.
 #
 
-# There are envioronment variables you may want to change, such as ROS_DISTRO,
-# ROSINSTALL_FILE, and the CATKIN_OPTIONS file.  See the README.md for more
-# information on these flags, and
 # https://docs.travis-ci.com/user/environment-variables/ for information about
 # Travis environment variables in general.
 #
-# Author: Felix Duvallet <felixd@gmail.com>
 
 # NOTE: The build lifecycle on Travis.ci is something like this:
 #    before_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,121 @@
+# Generic .travis.yml file for running continuous integration on Travis-CI for
+# any ROS package.
+#
+# Available here:
+#   - https://github.com/felixduvallet/ros-travis-integration
+#
+# This installs ROS on a clean Travis-CI virtual machine, creates a ROS
+# workspace, resolves all listed dependencies, and sets environment variables
+# (setup.bash). Then, it compiles the entire ROS workspace (ensuring there are
+# no compilation errors), and runs all the tests. If any of the compilation/test
+# phases fail, the build is marked as a failure.
+#
+# We handle two types of package dependencies specified in the package manifest:
+#   - system dependencies that can be installed using `rosdep`, including other
+#     ROS packages and system libraries. These dependencies must be known to
+#     `rosdistro` and are installed using apt-get.
+#   - package dependencies that must be checked out from source. These are handled by
+#     `wstool`, and should be listROS kineticed in a file named dependencies.rosinstall.
+#
+
+# There are envioronment variables you may want to change, such as ROS_DISTRO,
+# ROSINSTALL_FILE, and the CATKIN_OPTIONS file.  See the README.md for more
+# information on these flags, and
+# https://docs.travis-ci.com/user/environment-variables/ for information about
+# Travis environment variables in general.
+#
+# Author: Felix Duvallet <felixd@gmail.com>
+
+# NOTE: The build lifecycle on Travis.ci is something like this:
+#    before_install
+#    install
+#    before_script
+#    script
+#    after_success or after_failure
+#    after_script
+#    OPTIONAL before_deploy
+#    OPTIONAL deploy
+#    OPTIONAL after_deploy
+
+################################################################################
+
+sudo: required
+cache:
+  - apt
+
+# Build all valid Ubuntu/ROS combinations available on Travis VMs.
+language: generic
+matrix:
+  include:
+  - name: "Xenial kinetic"
+    dist: xenial
+    env: ROS_DISTRO=kinetic
+
+# Configuration variables. All variables are global now, but this can be used to
+# trigger a build matrix for different ROS distributions if desired.
+env:
+  global:
+    - ROS_CI_DESKTOP="`lsb_release -cs`"  # e.g. [trusty|xenial|...]
+    - CI_SOURCE_PATH=$(pwd)
+    - ROSINSTALL_FILE=$CI_SOURCE_PATH/dependencies.rosinstall
+    - CATKIN_OPTIONS=$CI_SOURCE_PATH/catkin.options
+    - ROS_PARALLEL_JOBS='-j8 -l6'
+    # Set the python path manually to include /usr/-/python2.7/dist-packages
+    # as this is where apt-get installs python packages.
+    - PYTHONPATH=$PYTHONPATH:/usr/lib/python2.7/dist-packages:/usr/local/lib/python2.7/dist-packages
+
+################################################################################
+
+# Install system dependencies, namely a very barebones ROS setup.
+before_install:
+  - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
+  - sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+  - sudo apt-get update -qq
+  - sudo apt-get install dpkg
+  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-ros-base
+  - source /opt/ros/$ROS_DISTRO/setup.bash
+  # Prepare rosdep to install dependencies.
+  - sudo rosdep init
+  - rosdep update --include-eol-distros  # Support EOL distros.
+
+# Create a catkin workspace with the package under integration.
+install:
+  - mkdir -p ~/catkin_ws/src
+  - cd ~/catkin_ws/src
+  - catkin_init_workspace
+  # Create the devel/setup.bash (run catkin_make with an empty workspace) and
+  # source it to set the path variables.
+  - cd ~/catkin_ws
+  - catkin_make
+  - source devel/setup.bash
+  # Add the package under integration to the workspace using a symlink.
+  - cd ~/catkin_ws/src
+  - ln -s $CI_SOURCE_PATH .
+
+# Install all dependencies, using wstool first and rosdep second.
+# wstool looks for a ROSINSTALL_FILE defined in the environment variables.
+before_script:
+  # source dependencies: install using wstool.
+  - cd ~/catkin_ws/src
+  - wstool init
+  - if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
+  - wstool up
+  # package depdencies: install using rosdep.
+  - cd ~/catkin_ws
+  - rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+
+# Compile and test (mark the build as failed if any step fails). If the
+# CATKIN_OPTIONS file exists, use it as an argument to catkin_make, for example
+# to blacklist certain packages.
+#
+# NOTE on testing: `catkin_make run_tests` will show the output of the tests
+# (gtest, nosetest, etc..) but always returns 0 (success) even if a test
+# fails. Running `catkin_test_results` aggregates all the results and returns
+# non-zero when a test fails (which notifies Travis the build failed).
+script:
+  - source /opt/ros/$ROS_DISTRO/setup.bash
+  - cd ~/catkin_ws
+  - catkin_make $( [ -f $CATKIN_OPTIONS ] && cat $CATKIN_OPTIONS )
+  # Run the tests, ensuring the path is set correctly.
+  - source devel/setup.bash
+  - catkin_make run_tests && catkin_test_results

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,17 +66,41 @@ env:
 
 ################################################################################
 
-# Install system dependencies, namely a very barebones ROS setup.
 before_install:
+  # Install ROS
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
   - sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
   - sudo apt-get update -qq
   - sudo apt-get install dpkg
-  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-ros-base
+  - sudo apt-get install -y cmake make curl libcurl4-gnutls-dev autoconf automake libtool g++ unzip libbluetooth-dev bluez python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-ros-base
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init
   - rosdep update --include-eol-distros  # Support EOL distros.
+  # Install Wiiuse
+  - cd ~
+  - git clone https://github.com/wiiuse/wiiuse.git
+  - cd wiiuse
+  - mkdir build
+  - cd build
+  - cmake .. [-DCMAKE_INSTALL_PREFIX=/usr/local] [-DCMAKE_BUILD_TYPE=Release] [-DBUILD_EXAMPLE_SDL=NO]
+  - make && sudo make install
+  # Install apriltag
+  - cd ~
+  - git clone https://github.com/AprilRobotics/apriltag
+  - cd apriltag
+  - mkdir build
+  - cd build
+  - cmake ..
+  - make && sudo make install  
+  # Install apriltag_ros
+  - cd ~
+  - mkdir -p apriltag_ws/src
+  - cd apriltag_ws/src
+  - git clone https://github.com/AprilRobotics/apriltag_ros.git
+  - cd ..
+  - rosdep install --from-paths src --ignore-src -r -y
+  - catkin_make_isolated
 
 # Create a catkin workspace with the package under integration.
 install:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 # EXTERNAL PACKAGES
-find_package(OpenCV REQUIRED)
+# find_package(OpenCV REQUIRED)
 # find_library(APRIL_TAG apriltag)
 # find_library(WIIMOTE wiiuse)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ generate_messages(
   geometry_msgs
 )
 catkin_package(
-  CATKIN_DEPENDS message_runtime roscpp rospy std_msgs geometry_msgs
+  CATKIN_DEPENDS message_runtime roscpp rospy std_msgs geometry_msgs rosconsole
   )
 
 
@@ -81,6 +81,10 @@ target_link_libraries(kernel ${catkin_LIBRARIES} kermitcpp kermitc)
 # target_link_libraries(camera_simul ${catkin_LIBRARIES} kermitcpp kermitc)
 # target_link_libraries(kermit ${catkin_LIBRARIES} kermitcpp kermitc)
 # target_link_libraries(kermit_wii ${catkin_LIBRARIES} kermitcpp kermitc)
+
+# Unit tests
+catkin_add_gtest(utest test/utest.cpp)
+target_link_libraries(utest ${catkin_LIBRARIES} kermitcpp kermitc)
 
 
 # INSTALLATION INSTRUCTIONS

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/curmc/sentinet_ros.svg?branch=master)](https://travis-ci.org/curmc/sentinet_ros)
 # Installation
 
 Linux support only at the moment

--- a/package.xml
+++ b/package.xml
@@ -41,6 +41,8 @@
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>rosconsole</exec_depend>
+
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/cpp/kernel/Kernel.cpp
+++ b/src/cpp/kernel/Kernel.cpp
@@ -87,18 +87,18 @@ bool Kernel::KermitSimulation::cmd_vel_callback(float lin, float ang) {
                 double y_pos_ = y_pos + sin(yaw) * veloc * dt;
 
                 // TODO is this necessary?
-                x_pos = (isnan(x_pos) ? x_pos : x_pos_);
-                y_pos = (isnan(y_pos) ? y_pos : y_pos_);
+                x_pos = (std::isnan(x_pos) ? x_pos : x_pos_);
+                y_pos = (std::isnan(y_pos) ? y_pos : y_pos_);
 
         } else {
 
-                assert(!isnan(veloc));
-                assert(!isnan(angular));
+                assert(!std::isnan(veloc));
+                assert(!std::isnan(angular));
 
                 float r = veloc / angular;
 
                 // TODO is this necessary?
-                assert(!isnan(r));
+                assert(!std::isnan(r));
 
                 // Update yaw
                 float yaw_new = yaw + angular * dt;
@@ -108,8 +108,8 @@ bool Kernel::KermitSimulation::cmd_vel_callback(float lin, float ang) {
                 double y_pos_ = y_pos + r * (sin(yaw_new) - sin(yaw));
 
                 // TODO is this necessary?
-                x_pos = (isnan(x_pos) ? x_pos : x_pos_);
-                y_pos = (isnan(y_pos) ? y_pos : y_pos_);
+                x_pos = (std::isnan(x_pos) ? x_pos : x_pos_);
+                y_pos = (std::isnan(y_pos) ? y_pos : y_pos_);
 
                 // Normailze yaw by constraining in [-pi, pi]
                 yaw = angle_normalize(yaw_new);
@@ -162,11 +162,11 @@ Kernel::KermitSimulation::KermitSimulation(ros::NodeHandle &handle,
 Kernel::KermitSimulation::~KermitSimulation() {}
 
 void Kernel::cmd_vel_callback(const geometry_msgs::Twist &msg) {
-        if (debug){
+        if (debug) {
                 debug_printf(msg);
         }
 
-        float lin = msg.linear.x; 
+        float lin = msg.linear.x;
         float ang = msg.angular.z;
 
         bool status = false;
@@ -176,8 +176,9 @@ void Kernel::cmd_vel_callback(const geometry_msgs::Twist &msg) {
         else
                 status = teensy_callback(lin, ang);
 
-        if (!status){
-                std::cout<<"Error. Showing most recent Command State:"<<std::endl;
+        if (!status) {
+                std::cout << "Error. Showing most recent Command State:"
+                          << std::endl;
                 debug_printf(msg);
         }
 

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char *argv[]) {
+        testing::InitGoogleTest(&argc, argv);
+        ros::init(argc, argv, "tester");
+        ros::NodeHandle nh;
+        return RUN_ALL_TESTS();
+}

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -1,6 +1,23 @@
 #include <gtest/gtest.h>
 #include <ros/ros.h>
 
+#include "kermit/kernel/Kernel.hpp"
+
+/* Gtest
+ * For a primer, visit:
+ * https://github.com/google/googletest/blob/master/googletest/docs/primer.md
+ */
+
+class HelloWorld {};
+
+TEST(HelloWorld, BasicTest) { ASSERT_EQ(1, 1); }
+
+TEST(KernelTest, InvalidTeensy) {
+        Kernel k{};
+        // I feel like this should return false
+        ASSERT_TRUE(k.initialize_teensy("aaaaaa"));
+}
+
 int main(int argc, char *argv[]) {
         testing::InitGoogleTest(&argc, argv);
         ros::init(argc, argv, "tester");

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <ros/ros.h>
 
 int main(int argc, char *argv[]) {
         testing::InitGoogleTest(&argc, argv);

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -14,7 +14,7 @@ TEST(HelloWorld, BasicTest) { ASSERT_EQ(1, 1); }
 
 TEST(KernelTest, InvalidTeensy) {
         Kernel k{};
-        // I feel like this should return false
+        // I feel like this should return false since I'm giving garbage values
         ASSERT_TRUE(k.initialize_teensy("aaaaaa"));
 }
 


### PR DESCRIPTION
Travis-Ci is all hooked up with gtest. Can be viewed at: 
https://travis-ci.org/curmc/sentinet_ros

Any new branches with the .travis.yml file will automatically run the unit tests we define on every commit to github, and travis will send an email if they fail. 

I just added the one tests/utest.cpp for unit tests, we can add more files for testing if we want to split them up. 

I removed opencv from the cmake requirements, since it seems we're not using it right now. I can add it back in if we need, it just means the tests will take a while to run since opencv isn't a quick project to build from source. 

I also just added the std:: prefix to the isnan calls, I was having linker issues on travis to recognize the c versions of isnan, but it found the cpp ones fine. 

Closes #26 